### PR TITLE
Fixing broken links in "about-libre-software-culture.html" file

### DIFF
--- a/about-libre-software-culture.html
+++ b/about-libre-software-culture.html
@@ -39,9 +39,9 @@ permalink: /about-libre-software-culture/index.html
                             <h2 class="text-center">Philosophy / Concepts</h2>
                             <hr>
                             <ul class="listDiscStyle" >
-                                <li class="listFont"><a href="www.gnu.org/philosophy/free-sw.html" class="hrefCustomColor">www.gnu.org/philosophy/free-sw.html</a></li>
-                                <li class="listFont"><a href="www.gnu.org/gnu/manifesto.en.html" class="hrefCustomColor">www.gnu.org/gnu/manifesto.en.html</a></li>
-                                <li class="listFont"><a href="www.gnu.org/philosophy/selling.html" class="hrefCustomColor">www.gnu.org/philosophy/selling.html</a></li>
+                                <li class="listFont"><a href="http://www.gnu.org/philosophy/free-sw.html" class="hrefCustomColor">www.gnu.org/philosophy/free-sw.html</a></li>
+                                <li class="listFont"><a href="http://www.gnu.org/gnu/manifesto.en.html" class="hrefCustomColor">www.gnu.org/gnu/manifesto.en.html</a></li>
+                                <li class="listFont"><a href="http://www.gnu.org/philosophy/selling.html" class="hrefCustomColor">www.gnu.org/philosophy/selling.html</a></li>
                                 <li class="listFont"><a href="http://www.ted.com/talks/luis_von_ahn_massive_scale_online_collaboration" class="hrefCustomColor">http://www.ted.com/talks/luis_von_ahn_massive_scale_online_collaboration</a></li>
                                 <li class="listFont"><a href="http://hintjens.com/blog:23 " class="hrefCustomColor">http://hintjens.com/blog:23 </a></li>     
                             </ul>
@@ -54,13 +54,12 @@ permalink: /about-libre-software-culture/index.html
                             <h2 class="text-center">Processes / Community</h2>
                             <hr>
                             <ul class="listDiscStyle">
-                                <li class="listFont"><a href="www.catb.org/esr/faqs/smart-questions.html#intro" class="hrefCustomColor">www.catb.org/esr/faqs/smart-questions.html#intro</a></li>
-                                <li class="listFont"><a href="www.producingoss.com" class="hrefCustomColor">www.producingoss.com</a></li>
+                                <li class="listFont"><a href="http://www.catb.org/esr/faqs/smart-questions.html#intro" class="hrefCustomColor">www.catb.org/esr/faqs/smart-questions.html#intro</a></li>
+                                <li class="listFont"><a href="http://www.producingoss.com" class="hrefCustomColor">www.producingoss.com</a></li>
                                 <li class="listFont"><a href="https://help.github.com/articles/good-resources-for-learning-git-and-github/" class="hrefCustomColor">https://help.github.com/articles/good-resources-for-learning-git-and-github/</a></li>
                                 <li class="listFont"><a href="https://www.google.com/search?q=david%20allen%20getting%20things%20done%20pdf" class="hrefCustomColor">https://www.google.com/search?q=david%20allen%20getting%20things%20done%20pdf</a></li>
                                 <li class="listFont"><a href="http://hintjens.com/blog:117" class="hrefCustomColor">http://hintjens.com/blog:117</a></li>
                                 <li class="listFont"><a href="http://www.chiark.greenend.org.uk/~sgtatham/bugs.html" class="hrefCustomColor">http://www.chiark.greenend.org.uk/~sgtatham/bugs.html</a></li>
-                                <li class="listFont"><a href="http://www.gweep.ca/~edmonds/usenet/ml-etiquette.html" class="hrefCustomColor">http://www.gweep.ca/~edmonds/usenet/ml-etiquette.html</a></li>
                             </ul>
                         </div>
                     </div> 


### PR DESCRIPTION
Clicking some of the external links in https://www.sugarlabs.org/about-libre-software-culture/ shows "404 Not found" error. 

![image](https://user-images.githubusercontent.com/44440524/50371051-60b49400-05d9-11e9-9e89-da7374faa4df.png)

In the commit, first five have been fixed by Url Syntax upadation. The last one has been removed because it no longer exists. 
