### PR TITLE
Dynamically update copyright year based on latest commit date

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -82,7 +82,7 @@
                 <div class="row" >
                     <div class="col-md-12" style="margin-top:12px;">
                         <p style="font-size:13px;" class='text-center-md'>
-                        Copyright &copy; 2024 Sugar Labs&reg; available under the <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License(CC BY-SA)</a>.</br>
+                        Copyright &copy; <span id="year">2024</span> Sugar Labs&reg; available under the <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License(CC BY-SA)</a>.</br>
                         Website base template: Designed and developed by Themefisher
                         </p>
                     </div>
@@ -102,11 +102,41 @@ if (typeof jQuery.waypoints == 'undefined') {
 </script>
 
 <!-- Inline Javascript scripts -->
+
 <script  type="text/javascript">
 	$(document).on('click', "a[href='#top']", function (e) {
         $('html, body').animate({ scrollTop: 0 }, 'slow');
         return false;
     })
+    async function getLatestCommitDate() {
+        const url = `https://api.github.com/repos/${repo}/commits?per_page=1`;
+        const response = await fetch(url);
+
+        if (!response.ok) {
+        console.error('Failed to fetch commits');
+            return null;
+        }
+        const commits = await response.json();
+        if (commits.length > 0) {
+            return new Date(commits[0].commit.author.date);
+        } else {
+        console.error('No commits found for the repository');
+            return null;
+        }
+    }
+    async function updateCopyrightYear() {
+        const latestCommitDate = await getLatestCommitDate();
+
+        if (latestCommitDate) {
+            const currentYear = new Date().getFullYear();
+            const latestCommitYear = latestCommitDate.getFullYear();
+
+            const yearElement = document.getElementById('year');
+            yearElement.textContent = latestCommitYear;
+        }
+    }
+    updateCopyrightYear();
+    });
     $(document).ready(function () {
         $('#dismiss, .overlay').on('click', function () {
             $('#sidebar').removeClass('active');


### PR DESCRIPTION
I’m contributing to the project for the first time and have added a feature to dynamically update the footer copyright year based on the latest GitHub commit date.

1. Code: Fetches the latest commit date from the GitHub API and updates the footer year.
2. Verification: Clone the repo, check the footer in a browser, and verify the year updates correctly.

Please review the changes and guide me if there are any adjustments needed before merging.

Thanks!