### PR TITLE
Fixed #465 Story1 and Reference Button Non-Functional on Width 991px to 1214px

### DIFF
--- a/css/airspace.css
+++ b/css/airspace.css
@@ -1850,6 +1850,8 @@ px      68    160    252    344    436    */
 
 
 #exTab3 .nav-pills > li > a {
+  z-index: 10;
+  position: relative;
   border-radius: 30px 30px 30px 30px ;
  border: 1px solid #474354;
  -webkit-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);


### PR DESCRIPTION
Summary
Fixes an issue where the Story1 and Reference buttons were not functioning between screen widths of 991px and 1214px.

Problem
The buttons in the /sugar-stories section did not respond to clicks when viewed on devices with a screen width between 991px and 1214px. This impacted the user experience as the buttons were not usable in this specific range.

Fix
Adjusted the z-index and position properties in the CSS:

Added z-index: 10;
Set position: relative;
This ensures the buttons now respond properly to clicks in the specified screen width range.

Fixes #465 