### PR TITLE
fix: remove redundant JS loop and limit press rendering to HTML

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -122,34 +122,3 @@ $(document).ready(function(){
     	});
     };
 });
-
-//limit to 10 entries in press page
-const listItems = document.querySelectorAll("#myList li");
-listItems.forEach((item, index) => {
-  if (index >= 10) {
-    item.classList.add("d-none");
-  }
-});
-
-// show more and show less button in press page
-const items = document.querySelectorAll(".list-item");
-const showMoreBtn = document.getElementById("showMoreBtn");
-const showLessBtn = document.getElementById("showLessBtn");
-
-showMoreBtn.addEventListener("click", function () {
-  items.forEach((item, index) => {
-    item.classList.remove("d-none"); // Show hidden items
-  });
-  showMoreBtn.classList.add("d-none"); // Hide Show More button
-  showLessBtn.classList.remove("d-none"); // Show Show Less button
-});
-
-showLessBtn.addEventListener("click", function () {
-    items.forEach((item, index) => {
-      if (index >= 10) {
-        item.classList.add("d-none"); // Hide items again
-      }
-    });
-    showLessBtn.classList.add("d-none"); // Hide Show Less button
-    showMoreBtn.classList.remove("d-none"); // Show Show More button
-  });

--- a/press.html
+++ b/press.html
@@ -34,19 +34,54 @@ permalink: /press/index.html
     </div>
     <div class="container mt-5 my-2">
         <div class="border-bottom pb-3 mb-3">
-            <ol id="myList">
-                {% for post in site.posts %} <li class="list-item">
-                 <div class="text-muted mb-1 h6">{{ post.date | date: "%b %-d %Y" }}</div>
-                 <div class="h5" >
+            <ol id="postList">
+                {% for post in site.posts limit:10 %}
+                <li class="listFont">
                     <a href="{{ post.url }}">{{ post.title }}</a>
-                 </div>
-                 <hr>
-                </li>{% endfor %}
+                    <i style="display: block;">{{ post.date | date: "%b %-d %Y" }}</i>
+                    <hr>
+                </li>
+                {% endfor %}
             </ol>
-            <div class="text-center">
-                <button id="showMoreBtn" class="btn btn-primary mt-3">Show More</button>
-                <button id="showLessBtn" class="btn btn-secondary mt-3 d-none">Show Less</button>
-            </div>
+            <button style="
+                display: block;
+                margin: 0 auto;
+                cursor: pointer;
+                " id="toggleButton" onclick="togglePost()">Show More
+            </button>
+            <script>
+                const postListEl = document.getElementById("postList");
+                const toggleBtn = document.getElementById("toggleButton");
+                let isShowingAll = false;
+            
+                function togglePost() {
+                    if (!isShowingAll) {
+                        postListEl.innerHTML = `
+                            {% for post in site.posts %}
+                            <li class="listFont">
+                                <a href="{{ post.url }}">{{ post.title }}</a>
+                                <i style="display: block;">{{ post.date | date: "%b %-d %Y" }}</i>
+                                <hr>
+                            </li>
+                            {% endfor %}
+                        `;
+                        toggleBtn.textContent = "Show Less";
+                        isShowingAll = true;
+                    } else {
+                        postListEl.innerHTML = `
+                            {% for post in site.posts limit:10 %}
+                            <li class="listFont">
+                                <a href="{{ post.url }}">{{ post.title }}</a>
+                                <i style="display: block;">{{ post.date | date: "%b %-d %Y" }}</i>
+                                <hr>
+                            </li>
+                            {% endfor %}
+                        `;
+                        toggleBtn.textContent = "Show More";
+                        isShowingAll = false;
+                    }
+                }
+            </script>
         </div>
     </div>
 </section>


### PR DESCRIPTION
Fixes #456

There was an unnecessary loop in the JS file to limit the displayed press, since the HTML already has a loop for this purpose. I believe we should only use the HTML loop to limit the posts. I think this approach is much better.

@pikurasa What do you think about it ?