### PR TITLE
fix: responsive button design for download section

### DIFF
--- a/css/airspace.css
+++ b/css/airspace.css
@@ -276,6 +276,14 @@ font header .navbar-default .navbar-nav li a:hover {
   margin: 0;
   font-size: 30px;
 }
+@media screen and (min-width: 768px) and (max-width: 1043px) {
+   #call-to-action button {
+    display: block;
+    margin: 0 auto;
+    padding: 5px 10px;
+    font-size: 11px;
+  }
+}
 #call-to-action p {
   font-size: 14px;
   line-height: 1.6;


### PR DESCRIPTION
Fixes #491

Before:
<img width="791" alt="Screenshot 2024-10-18 at 10 54 07 AM" src="https://github.com/user-attachments/assets/22ff6777-3641-48d5-9704-7a31e1fb00a6">

After:
<img width="764" alt="Screenshot 2024-10-18 at 10 55 00 AM" src="https://github.com/user-attachments/assets/441fed11-8a24-479e-aa0f-42e605093650">
