### PR TITLE
Fix 545: text color of 'about us' option and 'news' option

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -19,41 +19,23 @@
                   aria-expanded="false"
                   >About us<span class="caret"></span
                 ></a>
-                <ul class="dropdown-menu">
-                  <li>
-                    <a class="dropdown-item" href="{{ site.baseurl }}/about-us"
-                      >About us</a
-                    >
-                  </li>
-                  <li>
-                    <a
-                      class="dropdown-item"
-                      href="{{ site.baseurl }}/about-us/#mission"
-                      >Our mission</a
-                    >
-                  </li>
-                  <li>
-                    <a
-                      class="dropdown-item"
-                      href="{{ site.baseurl }}/leadership"
-                      >Leadership and governance</a
-                    >
-                  </li>
-                  <li>
-                    <a
-                      class="dropdown-item"
-                      href="{{ site.baseurl }}/contact-us"
-                      >Contact us</a
-                    >
-                  </li>
-                  <li>
-                    <a
-                      class="dropdown-item"
-                      href="{{ site.baseurl }}/FAQ"
-                      >FAQs</a
-                    >
-                  </li>
-                </ul>
+                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                  <a class="dropdown-item" href="{{ site.baseurl }}/about-us"
+                    >About us</a
+                  >
+                  <a class="dropdown-item" href="{{ site.baseurl }}/about-us/#mission"
+                    >Our mission</a
+                  >
+                  <a class="dropdown-item" href="{{ site.baseurl }}/leadership"
+                    >Leadership and governance</a
+                  >
+                  <a class="dropdown-item" href="{{ site.baseurl }}/contact-us"
+                    >Contact us</a
+                  >
+                  <a class="dropdown-item" href="{{ site.baseurl }}/FAQ"
+                    >FAQs</a
+                  >
+                </div>
               </li>
 
 
@@ -67,27 +49,17 @@
                   aria-expanded="false"
                   >News<span class="caret"></span
                 ></a>
-                <ul class="dropdown-menu">
-                  <li>
-                    <a class="dropdown-item" href="{{ site.baseurl }}/community-news"
-                      >Community News</a
-                    >
-                  </li>
-                  <li>
-                    <a
-                      class="dropdown-item"
-                      href="{{ site.baseurl }}/event"
-                      >Events</a
-                    >
-                  </li>
-                  <li>
-                    <a
-                      class="dropdown-item"
-                      href="{{ site.baseurl }}/press"
-                      >Press Release</a
-                    >
-                  </li>
-                </ul>
+                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                  <a class="dropdown-item" href="{{ site.baseurl }}/community-news"
+                    >Community News</a
+                  >
+                  <a class="dropdown-item" href="{{ site.baseurl }}/event"
+                    >Events</a
+                  >
+                  <a class="dropdown-item" href="{{ site.baseurl }}/press"
+                    >Press Release</a
+                  >
+                </div>
               </li>
 
               <li class="nav-item">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -19,23 +19,41 @@
                   aria-expanded="false"
                   >About us<span class="caret"></span
                 ></a>
-                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                  <a class="dropdown-item" href="{{ site.baseurl }}/about-us"
-                    >About us</a
-                  >
-                  <a class="dropdown-item" href="{{ site.baseurl }}/about-us/#mission"
-                    >Our mission</a
-                  >
-                  <a class="dropdown-item" href="{{ site.baseurl }}/leadership"
-                    >Leadership and governance</a
-                  >
-                  <a class="dropdown-item" href="{{ site.baseurl }}/contact-us"
-                    >Contact us</a
-                  >
-                  <a class="dropdown-item" href="{{ site.baseurl }}/FAQ"
-                    >FAQs</a
-                  >
-                </div>
+                <ul class="dropdown-menu">
+                  <li>
+                    <a class="dropdown-item" href="{{ site.baseurl }}/about-us"
+                      >About us</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      class="dropdown-item"
+                      href="{{ site.baseurl }}/about-us/#mission"
+                      >Our mission</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      class="dropdown-item"
+                      href="{{ site.baseurl }}/leadership"
+                      >Leadership and governance</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      class="dropdown-item"
+                      href="{{ site.baseurl }}/contact-us"
+                      >Contact us</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      class="dropdown-item"
+                      href="{{ site.baseurl }}/FAQ"
+                      >FAQs</a
+                    >
+                  </li>
+                </ul>
               </li>
 
 
@@ -49,17 +67,27 @@
                   aria-expanded="false"
                   >News<span class="caret"></span
                 ></a>
-                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                  <a class="dropdown-item" href="{{ site.baseurl }}/community-news"
-                    >Community News</a
-                  >
-                  <a class="dropdown-item" href="{{ site.baseurl }}/event"
-                    >Events</a
-                  >
-                  <a class="dropdown-item" href="{{ site.baseurl }}/press"
-                    >Press Release</a
-                  >
-                </div>
+                <ul class="dropdown-menu">
+                  <li>
+                    <a class="dropdown-item" href="{{ site.baseurl }}/community-news"
+                      >Community News</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      class="dropdown-item"
+                      href="{{ site.baseurl }}/event"
+                      >Events</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      class="dropdown-item"
+                      href="{{ site.baseurl }}/press"
+                      >Press Release</a
+                    >
+                  </li>
+                </ul>
               </li>
 
               <li class="nav-item">
@@ -117,23 +145,41 @@
           >
             About us
           </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <a class="dropdown-item" href="{{ site.baseurl }}/about-us"
-              >About us</a
-            >
-            <a class="dropdown-item" href="{{ site.baseurl }}/about-us/#mission"
-              >Our mission</a
-            >
-            <a class="dropdown-item" href="{{ site.baseurl }}/leadership"
-              >Leadership and governance</a
-            >
-            <a class="dropdown-item" href="{{ site.baseurl }}/contact-us"
-              >Contact us</a
-            >
-            <a class="dropdown-item" href="{{ site.baseurl }}/FAQ"
-              >FAQs</a
-            >
-          </div>
+          <ul class="dropdown-menu">
+            <li>
+              <a class="dropdown-item" href="{{ site.baseurl }}/about-us"
+                >About us</a
+              >
+            </li>
+            <li>
+              <a
+                class="dropdown-item"
+                href="{{ site.baseurl }}/about-us/#mission"
+                >Our mission</a
+              >
+            </li>
+            <li>
+              <a
+                class="dropdown-item"
+                href="{{ site.baseurl }}/leadership"
+                >Leadership and governance</a
+              >
+            </li>
+            <li>
+              <a
+                class="dropdown-item"
+                href="{{ site.baseurl }}/contact-us"
+                >Contact us</a
+              >
+            </li>
+            <li>
+              <a
+                class="dropdown-item"
+                href="{{ site.baseurl }}/FAQ"
+                >FAQs</a
+              >
+            </li>
+          </ul>
         </li>
         <li class="nav-item dropdown">
           <a
@@ -147,17 +193,27 @@
           >
             News
           </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <a class="dropdown-item" href="{{ site.baseurl }}/community-news"
-              >Community News</a
-            >
-            <a class="dropdown-item" href="{{ site.baseurl }}/event"
-              >Events</a
-            >
-            <a class="dropdown-item" href="{{ site.baseurl }}/press"
-              >Press Release</a
-            >
-          </div>
+          <ul class="dropdown-menu">
+            <li>
+              <a class="dropdown-item" href="{{ site.baseurl }}/community-news"
+                >Community News</a
+              >
+            </li>
+            <li>
+              <a
+                class="dropdown-item"
+                href="{{ site.baseurl }}/event"
+                >Events</a
+              >
+            </li>
+            <li>
+              <a
+                class="dropdown-item"
+                href="{{ site.baseurl }}/press"
+                >Press Release</a
+              >
+            </li>
+          </ul>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="{{ site.baseurl }}/#try">Try now</a>


### PR DESCRIPTION
Fixed the issue raised in #545 

## Issue
Navbar tabs were showing two different colors in two different window sizes.

## Fix

- Fixed by modifying the nav.html without affecting any other behaviour.

## Output
![image](https://github.com/user-attachments/assets/1ff88980-590f-4b77-873e-ce7406137283)
![image](https://github.com/user-attachments/assets/3809751a-9b01-4a86-9b26-0eee6df2436a)
