### PR TITLE
Fixed deprecated sass functions

### DIFF
--- a/css/ion_icon_customization.scss
+++ b/css/ion_icon_customization.scss
@@ -4,56 +4,57 @@
 // Somewhat based off Social Share Kit - https://github.com/darklow/social-share-kit/blob/master/dist/css/social-share-kit.css
 
 // By default the hover color is darkened. You can set the percent below
+@use "sass:color";
 $darken-percent: 10%;
 
 // Facebook colors
 $facebook-color: white;
-$facebook-color-hover: darken($facebook-color, $darken-percent);
+$facebook-color-hover: color.adjust($facebook-color, $lightness: -$darken-percent);
 $facebook-background: #1877f2;
-$facebook-background-hover: darken($facebook-background, $darken-percent);
+$facebook-background-hover: color.adjust($facebook-background, $lightness: -$darken-percent);
 
 // Github colors
 $github-color: white;
-$github-color-hover: darken($github-color, $darken-percent);
+$github-color-hover: color.adjust($github-color, $lightness: -$darken-percent);
 $github-background: black;
-$github-background-hover: darken($github-background, $darken-percent);
+$github-background-hover: color.adjust($github-background, $lightness: -$darken-percent);
 
 // X colors
 $X-color: white;
-$X-color-hover: darken($X-color, $darken-percent);
+$X-color-hover: color.adjust($X-color, $lightness: -$darken-percent);
 $X-background: black;
-$X-background-hover: darken($X-background, $darken-percent);
+$X-background-hover: color.adjust($X-background, $lightness: -$darken-percent);
 
 // Instagram colors
 // Instagram uses the background on both for both sticky and non sticky icons
 $instagram-color: white;
 $instagram-color-hover: #d9a1f1;
 $instagram-background: linear-gradient(#4c4bdb85, transparent), linear-gradient(60deg, #ffff00, #ff00d3, #0e39dc);
-$instagram-background-hover: linear-gradient(darken(#4c4bdb85, $darken-percent), darken(transparent, $darken-percent)), linear-gradient(60deg, darken(#ffff00, $darken-percent), darken(#ff00d3, $darken-percent), darken(#0e39dc, $darken-percent));
+$instagram-background-hover: linear-gradient(color.adjust(#4c4bdb85, $lightness: -$darken-percent), color.adjust(transparent, $lightness: -$darken-percent)), linear-gradient(60deg, color.adjust(#ffff00, $lightness: -$darken-percent), color.adjust(#ff00d3, $lightness: -$darken-percent), color.adjust(#0e39dc, $lightness: -$darken-percent));
 
 // Youtube colors
 $youtube-color: white;
-$youtube-color-hover: darken($youtube-color, $darken-percent);
+$youtube-color-hover: color.adjust($youtube-color, $lightness: $darken-percent);
 $youtube-background: red;
-$youtube-background-hover: darken($youtube-background, $darken-percent);
+$youtube-background-hover: color.adjust($youtube-background, $lightness: -$darken-percent);
 
 // Mastodon colors
 $mastodon-color: white;
-$mastodon-color-hover: darken($mastodon-color, $darken-percent);
+$mastodon-color-hover: color.adjust($mastodon-color, $lightness: -$darken-percent);
 $mastodon-background: #3088d4;
-$mastodon-background-hover: darken($mastodon-background, $darken-percent);
+$mastodon-background-hover: color.adjust($mastodon-background, $lightness: -$darken-percent);
 
 // LinkedIn colors
 $linkedin-color: white;
-$linkedin-color-hover: darken($linkedin-color, $darken-percent);
+$linkedin-color-hover: color.adjust($linkedin-color, $lightness: -$darken-percent);
 $linkedin-background: #0077b5;
-$linkedin-background-hover: darken($linkedin-background, $darken-percent);
+$linkedin-background-hover: color.adjust($linkedin-background, $lightness: -$darken-percent);
 
 // Medium colors
 $medium-color: white;
-$medium-color-hover: darken($medium-color, $darken-percent);
+$medium-color-hover: color.adjust($medium-color, $lightness: -$darken-percent);
 $medium-background: black;
-$medium-background-hover: darken($medium-background, $darken-percent);
+$medium-background-hover: color.adjust($medium-background, $lightness: -$darken-percent);
 
 .ion-sticky {
   top: 50%;

--- a/css/ion_icon_customization.scss
+++ b/css/ion_icon_customization.scss
@@ -34,7 +34,7 @@ $instagram-background-hover: linear-gradient(color.adjust(#4c4bdb85, $lightness:
 
 // Youtube colors
 $youtube-color: white;
-$youtube-color-hover: color.adjust($youtube-color, $lightness: $darken-percent);
+$youtube-color-hover: color.adjust($youtube-color, $lightness: -$darken-percent);
 $youtube-background: red;
 $youtube-background-hover: color.adjust($youtube-background, $lightness: -$darken-percent);
 


### PR DESCRIPTION
`darken()` is a deprecated global built-in function. It uses a legacy method for color manipulation that lead to several deprecation warnings on the terminal at best, and can lead to inconsistent results at worst (see [what the sass documentation has to say about it](https://sass-lang.com/documentation/breaking-changes/import/)).

 `color.adjust()` provides a more modern, flexible, and predictable approach to adjusting specific color properties and is the recommended approach by the official sass documentation.

I have replaced the deprecated `darken()` function with `color.adjust()` to have the exact same visual effect for the viewer as intended by the original design.

##### Before (using deprecated `darken()`)

![before (1)](https://github.com/user-attachments/assets/99340807-6416-4a8c-9210-0fc54088434f)

![7f6da252-d2b2-4f4e-af20-15de241c2990](https://github.com/user-attachments/assets/7393acbf-e20b-4457-a5bf-dbe0c0e6146c)


##### After (using recommended `color.adjust()`)

![after (1)](https://github.com/user-attachments/assets/5eba9895-ba71-4619-a465-445eec92f34a)

![ded5e28f-ff03-43ed-8efb-b4003ff79ac7](https://github.com/user-attachments/assets/91906c6b-fc80-4fbc-85d2-56c354f8ee0c)

