### PR TITLE
Fixes #545 text color of "about us" option and "news" option

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -20,39 +20,16 @@
                   >About us<span class="caret"></span
                 ></a>
                 <ul class="dropdown-menu">
-                  <li>
-                    <a class="dropdown-item" href="{{ site.baseurl }}/about-us"
-                      >About us</a
-                    >
-                  </li>
-                  <li>
-                    <a
-                      class="dropdown-item"
-                      href="{{ site.baseurl }}/about-us/#mission"
-                      >Our mission</a
-                    >
-                  </li>
-                  <li>
-                    <a
-                      class="dropdown-item"
-                      href="{{ site.baseurl }}/leadership"
-                      >Leadership and governance</a
-                    >
-                  </li>
-                  <li>
-                    <a
-                      class="dropdown-item"
-                      href="{{ site.baseurl }}/contact-us"
-                      >Contact us</a
-                    >
-                  </li>
-                  <li>
-                    <a
-                      class="dropdown-item"
-                      href="{{ site.baseurl }}/FAQ"
-                      >FAQs</a
-                    >
-                  </li>
+                 <a class="dropdown-item" href="{{ site.baseurl }}/about-us"
+                 >About us</a>
+                 <a class="dropdown-item" href="{{ site.baseurl }}/about-us/#mission"
+                 >Our mission</a>
+                 <a class="dropdown-item" href="{{ site.baseurl }}/leadership"
+                 >Leadership and governance</a>
+                 <a class="dropdown-item" href="{{ site.baseurl }}/contact-us"
+                 >Contact us</a>
+                 <a class="dropdown-item" href="{{ site.baseurl }}/FAQ"
+                 >FAQs</a> 
                 </ul>
               </li>
 
@@ -68,25 +45,13 @@
                   >News<span class="caret"></span
                 ></a>
                 <ul class="dropdown-menu">
-                  <li>
-                    <a class="dropdown-item" href="{{ site.baseurl }}/community-news"
-                      >Community News</a
-                    >
-                  </li>
-                  <li>
-                    <a
-                      class="dropdown-item"
-                      href="{{ site.baseurl }}/event"
-                      >Events</a
-                    >
-                  </li>
-                  <li>
-                    <a
-                      class="dropdown-item"
-                      href="{{ site.baseurl }}/press"
-                      >Press Release</a
-                    >
-                  </li>
+                <a class="dropdown-item"
+                  href="{{ site.baseurl }}/community-news"
+                  >Community News</a>
+                <a class="dropdown-item" href="{{ site.baseurl }}/event"
+                  >Events</a>
+                <a class="dropdown-item" href="{{ site.baseurl }}/press"
+                  >Press Release</a>
                 </ul>
               </li>
 

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -19,7 +19,7 @@
                   aria-expanded="false"
                   >About us<span class="caret"></span
                 ></a>
-                <ul class="dropdown-menu">
+                <div class="dropdown-menu">
                  <a class="dropdown-item" href="{{ site.baseurl }}/about-us"
                  >About us</a>
                  <a class="dropdown-item" href="{{ site.baseurl }}/about-us/#mission"
@@ -30,7 +30,7 @@
                  >Contact us</a>
                  <a class="dropdown-item" href="{{ site.baseurl }}/FAQ"
                  >FAQs</a> 
-                </ul>
+                </div>
               </li>
 
 
@@ -44,7 +44,7 @@
                   aria-expanded="false"
                   >News<span class="caret"></span
                 ></a>
-                <ul class="dropdown-menu">
+                <div class="dropdown-menu">
                 <a class="dropdown-item"
                   href="{{ site.baseurl }}/community-news"
                   >Community News</a>
@@ -52,7 +52,7 @@
                   >Events</a>
                 <a class="dropdown-item" href="{{ site.baseurl }}/press"
                   >Press Release</a>
-                </ul>
+                </div>
               </li>
 
               <li class="nav-item">


### PR DESCRIPTION
Fixes #545 
This is how it look like 
![dropdown](https://github.com/user-attachments/assets/c9d3dbb2-2ea9-4021-841a-57f65e01d2bc)
![dropdown 2](https://github.com/user-attachments/assets/3346059d-f5cf-4d88-8dd6-1fc59b17b6b5)

@quozl @pikurasa please review.