### PR TITLE
Update index.html to make the text below navbar visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ title: Sugar Labs
         <div class="row justify-content-center">
           <div class="col-md-10 col-md-push-1">
             <div class="block">
-              <h2 style=" text-transform: uppercase;">Sugar Labs</h2>
+              <h2 style=" text-transform: uppercase; margin-top: 4rem;">Sugar Labs</h2>
               <p>
                 Whether you're a young learner,
                 teacher, or a budding developer, we


### PR DESCRIPTION
This PR adjusts the spacing to prevent the text below navbar from being hidden. 
The issue #574 was identified on the homepage, where the "Sugar Labs" heading was obscured by the navbar. I've added some spacing to ensure proper visibility.

Changes made:
Increased top margin for the "Sugar Labs" heading to create space between it and the navbar.
Ensured the page remains responsive across various screen sizes.

Screenshots:
Before 
![old sugarlabs title page](https://github.com/user-attachments/assets/490caf7f-fa09-48d6-ac2b-63a1f5b93112)
After adding margin
![new sugarlabs title page](https://github.com/user-attachments/assets/718eff77-5a47-4704-a6a3-1dfc306d9ce4)

Please review this and let me know if any further changes are needed.

