### PR TITLE
 Add merch section to the front page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,16 @@ title: Sugar Labs
     </div>
   </div>
 </section>
+<section id="merch" class="merch-section">
+  <div class="container">
+    <h2>Support Sugar Labs with Merch!</h2>
+    <p>Check out our exclusive Sugar Labs merchandise and support our mission to provide educational tools for children around the world.</p>
+    <a href="https://www.bonfire.com/store/sugar-labs-merch/" target="_blank" class="button">
+      Visit the Store
+    </a>
+  </div>
+</section>
+
 
 <!-- Sugar Labs mission section -->
 <section id="intro" class="zeroMarPadBtm">


### PR DESCRIPTION
Added a new section to inform visitors about the Sugar Labs merch store, linking to the Bonfire store.
Added a new merch section to the front page, including a brief description and a link to the [Bonfire store](https://www.bonfire.com/store/sugar-labs-merch/) to encourage support for Sugar Labs
 Changes Made
- Added a merch section to the homepage.
- Styled the section to match the existing theme.

 Testing
Tested locally to ensure proper rendering and functionality.
Related Issue
Implements the remaining part of the suggestion in #580 .
i attached the screenshot of code that i add in the html

![Screenshot (710)](https://github.com/user-attachments/assets/1c8ab554-e450-4c35-9069-76cece69daec)
![Screenshot (711)](https://github.com/user-attachments/assets/b8a93bd0-8d8b-4b36-b612-41f0cdd780fc)


 
