### PR TITLE
Added author name display to blog

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,24 +6,27 @@ layout: default
     <div class="container text-center">
       <h1 class="display-4 mb-0">{{ page.title }}</h1>
       <p class="lead">{{ page.date | date: "%b %-d %Y" }}</p> 
+
+      <!-- Author Display -->
+      <p class="lead">by <span class="fw-bold">{{ page.author }}</span></p>
     </div>
 </div>
 
- <!-- Content Section -->
+<!-- Content Section -->
 <div class="container my-5">
     <div class="bg-white p-4 rounded shadow-sm">
       {{ content }}
     </div>
 </div>
 
+<!-- Footer Section with Links -->
 <div class="bg-light py-4">
      <div class="container text-center">
       <p class="mb-2">
         <a href="/press" class="btn btn-outline-secondary btn-sm text-decoration-none">Return to press information</a>
-     </p>
+      </p>
       <p>
         <a href="/" class="btn btn-outline-secondary btn-sm text-decoration-none">Return to main page</a>
       </p>
     </div>
 </div>
-  

--- a/community-news.html
+++ b/community-news.html
@@ -38,7 +38,10 @@ permalink: /community-news/index.html
                 {% for post in site.categories.community limit:10 %}
                 <li class="listFont">
                     <a href="{{ post.url }}">{{ post.title }}</a>
-                    <i style="display: block;">{{ post.date | date: "%b %-d %Y" }}</i>
+                    <div>
+                        <span class="fw-bold me-3" style="font-size: 15px;">{{ post.author }}</span>
+                        <span class="text-muted" style="font-size: 12px;">{{ post.date | date: "%b %-d %Y" }}</span>
+                    </div>
                     <hr>
                 </li>
                 {% endfor %}


### PR DESCRIPTION
This PR addresses issue #571 by adding the author's name below the title of blog posts. The author’s name is fetched from the front matter and displayed in the blog layout as "by Author Name."

### Changes Made:
- Added dynamic display for the author name in the blog post layout.
- The `author` field in the front matter is now rendered below the post title.
- Updated CSS classes for styling the author name and post date.

### Issue Link:
Closes #571

### How to Test:
1. Add `author: "Author Name"` to the front matter of any blog post.
2. Verify that the author's name is correctly displayed below the post title.

### Additional Notes:
This implementation improves post attribution by clearly displaying the author's name for each blog post.

### Screenshots:
Before:
![image](https://github.com/user-attachments/assets/8cfd2ccc-8fae-4422-8533-05fd30cae1e2)
![image](https://github.com/user-attachments/assets/14b8aba5-0d54-460d-8603-e8f060cc0a7f)

After:
![image](https://github.com/user-attachments/assets/620b88a2-23b6-42cc-8e49-f98cd2ef5a0c)
![image](https://github.com/user-attachments/assets/27c21b9e-3b1e-4b2b-ae84-2c2fdbb1cf65)
