### PR TITLE
Fixes #644, Removed unnecessary left padding on various UL elements

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -63,7 +63,7 @@ permalink: /about-us/index.html
                             <div id="testimonial-slider2" class="owl-carousel">
                                 <div>
                                     <h4><b>Identity</b></h4>
-                                    <p><ul class="leftAlign">
+                                    <p><ul class="leftAlign px-5">
                                     <li>1. Clear mission – Fully disclosed objectives.</li>
                                     <li>2. Declared commitments – Affinities and aversions explained.</li>
                                     <li>3. Declared outside connections – Relationships with other organizations explicitly listed.</li>
@@ -71,7 +71,7 @@ permalink: /about-us/index.html
                                 </div>
                                 <div>
                                     <h4><b>Structure</b></h4>
-                                    <p><ul class="leftAlign">
+                                    <p><ul class="leftAlign px-5">
                                     <li>1. Horizontal organization – Teams and facilitators work on responsibilities and agreements.</li>
                                     <li>2. Identified contributors – Who is who, people are reachable.</li>
                                     <li>3. Clear responsibilities – Who is in charge of what.</li>
@@ -81,7 +81,7 @@ permalink: /about-us/index.html
                                 </div>
                                 <div>
                                     <h4><b>Operation</b></h4>
-                                    <p><ul class="leftAlign">
+                                    <p><ul class="leftAlign px-5">
                                     <li>1. Open participation – Anybody can access the information and get a first responsibility.</li>
                                     <li>2. Meritocracy – Responsibilities are acquired (or lost) based on one's skills, results, and contributors’ support.</li>
                                     <li>3. Voluntary (non-)engagement – Nobody is forced to be involved or to keep responsibilities.</li>
@@ -89,7 +89,7 @@ permalink: /about-us/index.html
                                 </div>
                                 <div>
                                     <h4><b>Information</b></h4>
-                                    <p><ul class="leftAlign">
+                                    <p><ul class="leftAlign px-5">
                                     <li>1. Regular reports – Reported activities and future plans allow monitoring and participation.</li>
                                     <li>2. Information accessible – Even internal operational information is available by default.</li>
                                     <li>3. Explicit confidentiality – It is explained what matters are confidential, why, and who can access them.</li>
@@ -98,7 +98,7 @@ permalink: /about-us/index.html
                                 </div>
                                 <div>
                                     <h4><b>Goods</b></h4>
-                                    <p><ul class="leftAlign">
+                                    <p><ul class="leftAlign px-5">
                                     <li>1. Economic model – Feasibility and sustainability plans are exposed. (Please see/contribute to the discussion here.)</li>
                                     <li>2. Resources – Inventory of items detailing who contributed what and why.</li>
                                     <li>3. Public accounts – It’s clear where the money comes from and where it goes.</li>

--- a/css/custom.css
+++ b/css/custom.css
@@ -283,6 +283,5 @@
 
 /* fix list rendering */
 ul {
-  padding: revert;
   list-style: inherit;
 }


### PR DESCRIPTION
This pull request addresses issues with the UL elements being right aligned due to left padding being applied in custom.css .

### Key changes:

- Removed `padding: revert` which was causing unnecessary left padding and misalignment of ul elements.
**Before:**
![Screenshot 2025-01-16 221044](https://github.com/user-attachments/assets/5544343f-7108-4f29-9364-24c49d494676)
**After:**
![image](https://github.com/user-attachments/assets/50d22bac-da8f-49ed-8edb-ab7dbdf2dd98)

**Before(footer)**:
![image](https://github.com/user-attachments/assets/e908980d-178a-4d48-8739-0a81ed2d154d)

**After(footer)**:
![image](https://github.com/user-attachments/assets/75f5e0b2-e595-4a95-a77b-8f120cacd817)

- Due to the removal of padding: revert the padding was set to 0 again for all the ul elements, because of which **only** the placement section was broken so added px-5 padding to the section which fixed all the things.
**Before(with padding:revert)**:
![image](https://github.com/user-attachments/assets/44198311-fe29-4fd4-8805-c8bc3f4dced7)

**After(with px-5)**:
![image](https://github.com/user-attachments/assets/3f7e4dcf-7fac-4e92-bb8e-0fa39814a0b9)
(remains the same)
