### PR TITLE
Utilizing blank space for carousel

### DIFF
--- a/contact-us.html
+++ b/contact-us.html
@@ -46,7 +46,7 @@ permalink: /contact-us/index.html
                 <div class="row">
                     <div class="col-md-12">
                         <div class="block">
-                            <div id="social-media-logos" class="owl-carousel">
+                            <div id="social-media-logos">
                                 <div class="social-media-logos-img">
                                     <a href="https://www.facebook.com/SugarLabs-187845102582/timeline/"><img src="{{ site.baseurl }}/assets/f.svg" alt="Facebook logo" class="customLogoImageStyle"></a>
                                 </div>


### PR DESCRIPTION
# Before

![{4A9091D2-2A08-41A8-B4E4-F37C8FD3CC7F}](https://github.com/user-attachments/assets/85d6304e-e362-4d80-972e-f1e187b7414b)

# After

![{489F7FAF-FCE6-4C55-9D06-59133DFBFC45}](https://github.com/user-attachments/assets/064e46b8-1ef3-4102-98e3-949c48b59d17)

Instead of removing the carousel, utilizing the width to add more icons seems a better idea.

Fixes #637 