### PR TITLE
Update the position of "Products" on nav

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -43,13 +43,11 @@
               <li class="nav-item">
                 <a class="nav-link" href="{{ site.baseurl }}/volunteering">Volunteer</a>
               </li>
-              <li class="nav-item dropdown align-self-center">
-                <a href="{{ site.baseurl }}/#" class="dropdown-toggle" data-toggle="dropdown" role="button"
-                  aria-haspopup="true" aria-expanded="false">Donate<span class="caret"></span></a>
-                <div class="dropdown-menu">
-                  <a class="dropdown-item" href="{{ site.baseurl }}/donate">Donate</a>
-                  <a class="dropdown-item" href="{{ site.baseurl }}/product">Products</a>
-                </div>
+              <li class="nav-item">
+                <a class="nav-link" href="{{ site.baseurl }}/donate">Donate</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="{{ site.baseurl }}/product">Products</a>
               </li>
             </ul>
           </div>
@@ -104,15 +102,11 @@
         <li class="nav-item">
           <a class="nav-link" href="{{ site.baseurl }}/volunteering">Volunteer</a>
         </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="{{ site.baseurl }}/#" id="navbarDropdown" role="button"
-            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Donate
-          </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <a class="dropdown-item" href="{{ site.baseurl }}/donate">Donate</a>
-            <a class="dropdown-item" href="{{ site.baseurl }}/product">Products</a>
-          </div>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ site.baseurl }}/donate">Donate</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ site.baseurl }}/product">Products</a>
         </li>
       </ul>
     </div>

--- a/sitemap.txt
+++ b/sitemap.txt
@@ -23,5 +23,6 @@ https://www.sugarlabs.org/sugar-for-raspbian/
 https://www.sugarlabs.org/sugar-for-raspberry-pi/
 https://www.sugarlabs.org/flatpak/
 https://www.sugarlabs.org/profiles/
+https://www.sugarlabs.org/product/
 {% for post in site.posts %}https://www.sugarlabs.org{{ post.url }}
 {% endfor %}


### PR DESCRIPTION
Updated the position of "Products" section from "Donate" dropdown to a separate item on navbar.

![Screenshot 2025-01-25 201223](https://github.com/user-attachments/assets/cc5caac5-a1d9-4e7d-9ab2-a83dac6c9030)

mobile:
![Screenshot 2025-01-25 201327](https://github.com/user-attachments/assets/77eca277-e4c3-489f-aea3-57c0356d80ed)

@pikurasa what do you think.
