### PR TITLE
Fixed missing dependencies issue by updating Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,26 @@
 source "https://rubygems.org"
-gem "jekyll", "~> 4.3.4"
-gem "minima", "~> 2.5"
+
+# Core Jekyll and theme
+gem "jekyll"
+gem "minima"
+
+# Jekyll plugins
 group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.12"
+  gem "jekyll-feed"
+  gem "github-pages"
+  gem "jekyll-sitemap"
 end
+
+# Platform-specific gems
 platforms :mingw, :x64_mingw, :mswin, :jruby do
-  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo"
   gem "tzinfo-data"
 end
-gem "wdm", "~> 0.1", :platforms => [:mingw, :x64_mingw, :mswin]
-gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
+
+gem "wdm", platforms: [:mingw, :x64_mingw, :mswin]
+gem "http_parser.rb", platforms: [:jruby]
+
+# Additional gems
+gem "bundler"
+gem "webrick"
+gem "rake"


### PR DESCRIPTION
When running bundle exec jekyll serve --incremental, an error occured. Investigation reveals that the issue is due to missing dependencies in the Gemfile, which was introduced by Commit `1dd0e41.` The changes in this commit removed essential dependencies, leading to this error.

- Fixes #670